### PR TITLE
Negative time parser

### DIFF
--- a/webvtt/parsers.py
+++ b/webvtt/parsers.py
@@ -155,7 +155,7 @@ class WebVTTParser(TextBasedParser):
     WebVTT parser.
     """
 
-    TIMEFRAME_LINE_PATTERN = re.compile(r'\s*((?:\d+:)?\d{2}:\d{2}.\d{3})\s*-->\s*((?:\d+:)?\d{2}:\d{2}.\d{3})')
+    TIMEFRAME_LINE_PATTERN = re.compile(r'\s*((?:-?\d+:)?-?\d{2}:-?\d{2}.-?\d{3})\s*-->\s*((?:-?\d+:)?-?\d{2}:-?\d{2}.-?\d{3})')
     COMMENT_PATTERN = re.compile(r'NOTE(?:\s.+|$)')
     STYLE_PATTERN = re.compile(r'STYLE[ \t]*$')
 

--- a/webvtt/structures.py
+++ b/webvtt/structures.py
@@ -2,7 +2,7 @@ import re
 
 from .errors import MalformedCaptionError
 
-TIMESTAMP_PATTERN = re.compile('(\d+)?:?(\d{2}):(\d{2})[.,](\d{3})')
+TIMESTAMP_PATTERN = re.compile(r'(\d+)?:?(\d{2}):(\d{2})[.,](\d{3})')
 
 __all__ = ['Caption']
 

--- a/webvtt/structures.py
+++ b/webvtt/structures.py
@@ -2,7 +2,7 @@ import re
 
 from .errors import MalformedCaptionError
 
-TIMESTAMP_PATTERN = re.compile(r'(\d+)?:?(\d{2}):(\d{2})[.,](\d{3})')
+TIMESTAMP_PATTERN = re.compile(r'(-?\d+)?:?(-?\d{2}):(-?\d{2})[.,](-?\d{3})')
 
 __all__ = ['Caption']
 


### PR DESCRIPTION
# Changes

## Refactoring the Regex

- Allowing VTT file to have negative times

## Reason

Some VTT files might have comments with negative timestamps. E.g.

```
WEBVTT

00:00:-02.-150 --> 00:00:02.129
<v Thor>And then yes, and then you click the it.</v>
```